### PR TITLE
Support git before 2.2.0

### DIFF
--- a/lib/git/commit.dart
+++ b/lib/git/commit.dart
@@ -5,7 +5,9 @@ class Commit {
   String rawDate;
   DateTime parsedDate;
 
-  DateTime get date => parsedDate ??= DateTime.parse(rawDate);
+  DateTime get date {
+    return parsedDate ??= DateTime.fromMillisecondsSinceEpoch(int.parse(rawDate) * 1000);
+  }
 
   @override
   String toString() {

--- a/lib/git/git_client.dart
+++ b/lib/git/git_client.dart
@@ -15,7 +15,7 @@ class GitClient {
 
   Future<List<Commit>> revList(String revision, {bool firstParentOnly = false}) async {
     // use commit date not author date. commit date is  the one between the prev and next commit. Author date could be anything
-    String result = await git('rev-list --pretty=%cI%n${firstParentOnly ? ' --first-parent' : ''} $revision',
+    String result = await git('rev-list --pretty=%ct%n${firstParentOnly ? ' --first-parent' : ''} $revision',
         emptyResultIsError: false);
     if (result == null) return [];
 


### PR DESCRIPTION
pretty format `%cI` was introduced in git `2.2.0` and therefore failed on previous versions. Moving to unix timestamp is as good but also works on previous versions 